### PR TITLE
🐛 Fix bug in monoblock examples.

### DIFF
--- a/examples/monoblock/monoblock.i
+++ b/examples/monoblock/monoblock.i
@@ -124,12 +124,8 @@ surfHeatFlux=10e6   # W/m^2
     ring_block_names = 'void pipe interlayer'
     background_block_names = monoblock
     interface_boundary_id_shift = 1000
-    interface_boundary_names = '
-      internal_boundary
-      pipe_boundary
-      interlayer_boundary
-    '
     external_boundary_name = monoblock_boundary
+    generate_side_specific_boundaries = true
   []
 
   [mesh_armour]

--- a/examples/monoblock/simple_monoblock.i
+++ b/examples/monoblock/simple_monoblock.i
@@ -111,8 +111,8 @@ blockTemp=100       # degC
     ring_block_names = 'interlayer_tri interlayer'
     background_block_names = monoblock
     interface_boundary_id_shift = 1000
-    interface_boundary_names = interlayer_boundary
     external_boundary_name = monoblock_boundary
+    generate_side_specific_boundaries = true
   []
 
   [mesh_armour]


### PR DESCRIPTION
Fix a bug where the monoblock examples failed to mesh due to a change in the MOOSE reactor module's PolygonConcentricCircleMeshGenerator object. The update causes ids to no longer be side specific by default. Passing a flag retains the previous behaviour and allows files to run. An unused line naming the boundaries without BCs must also be removed.