### PR TITLE
Change -> to . in IRMINSADMaterial.C to match change in MOOSE

### DIFF
--- a/src/materials/IRMINSADMaterial.C
+++ b/src/materials/IRMINSADMaterial.C
@@ -83,14 +83,14 @@ IRMINSADMaterial::subdomainSetup()
     // So we have to go through MaterialData here. We already performed the material property
     // requests through the MaterialPropertyInterface APIs in the INSAD kernels, so we should be
     // safe for dependencies
-    _boussinesq_alpha = &_material_data->getProperty<Real, true>(
+    _boussinesq_alpha = &_material_data.getProperty<Real, true>(
         _object_tracker->get<MaterialPropertyName>("alpha", _current_subdomain_id), 0, *this);
     _temperature =
         &_subproblem
              .getStandardVariable(
                  _tid, _object_tracker->get<std::string>("temperature", _current_subdomain_id))
              .adSln();
-    _ref_temp = &_material_data->getProperty<Real, false>(
+    _ref_temp = &_material_data.getProperty<Real, false>(
         _object_tracker->get<MaterialPropertyName>("ref_temp", _current_subdomain_id), 0, *this);
   }
   else


### PR DESCRIPTION
A recent MOOSE update required changes to INSADMaterial.C, which IRMINSADMaterial.C is based on, so Proteus wouldn't build with the updated MOOSE. Making the corresponding change to IRMINSADMaterial.C results in a successful Proteus build.