### PR TITLE
MHD examples: fix function deprecation

### DIFF
--- a/examples/mhd/incompressible_inductionless/development/step2_electric_potential.i
+++ b/examples/mhd/incompressible_inductionless/development/step2_electric_potential.i
@@ -49,17 +49,17 @@ U_AVG = 1
 [Functions]
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step3_navier_stokes.i
+++ b/examples/mhd/incompressible_inductionless/development/step3_navier_stokes.i
@@ -38,11 +38,11 @@ U_AVG = 1
 [Functions]
   [velocityInlet]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2d.i
@@ -53,10 +53,10 @@ U_AVG = 1
 [Functions]
   [velocityInlet]
     type = ParsedVectorFunction
-    vars = 'y_max'
-    vals = '1'
-    value_x = '(3/2) * ${U_AVG} * (1 - (y * y) / (y_max * y_max))'
-    value_y = '0'
+    symbol_names = 'y_max'
+    symbol_values = '1'
+    expression_x = '(3/2) * ${U_AVG} * (1 - (y * y) / (y_max * y_max))'
+    expression_y = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2ndOrderVelocity.i
+++ b/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2ndOrderVelocity.i
@@ -39,11 +39,11 @@ U_AVG = 1
 [Functions]
   [velocityInlet]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step4_lorentz_force_UxB.i
+++ b/examples/mhd/incompressible_inductionless/development/step4_lorentz_force_UxB.i
@@ -129,17 +129,17 @@ U_AVG = 1
 [Functions]
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step5_lorentz_force_E_field.i
+++ b/examples/mhd/incompressible_inductionless/development/step5_lorentz_force_E_field.i
@@ -135,17 +135,17 @@ U_AVG = 1
 [Functions]
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [epotFunction]
     type = ParsedFunction

--- a/examples/mhd/incompressible_inductionless/development/step6_coupled_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step6_coupled_2d.i
@@ -171,15 +171,15 @@ U_AVG = 1
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max'
-    vals = '1'
-    value_x = '(3/2) * ${U_AVG} * (1 - (y * y) / (y_max * y_max))'
-    value_y = '0'
+    symbol_names = 'y_max'
+    symbol_values = '1'
+    expression_x = '(3/2) * ${U_AVG} * (1 - (y * y) / (y_max * y_max))'
+    expression_y = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
+    expression_x = '0'
+    expression_y = '20'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step6_coupled_3d.i
+++ b/examples/mhd/incompressible_inductionless/development/step6_coupled_3d.i
@@ -88,7 +88,6 @@ U_AVG = 1
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step6_coupled_3d.i
+++ b/examples/mhd/incompressible_inductionless/development/step6_coupled_3d.i
@@ -226,17 +226,17 @@ U_AVG = 1
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_3d_NS_comparison.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_3d_NS_comparison.i
@@ -88,7 +88,6 @@ U_AVG = 1
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_3d_NS_comparison.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_3d_NS_comparison.i
@@ -180,11 +180,11 @@ U_AVG = 1
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_2d.i
@@ -174,15 +174,15 @@ U_AVG = 1
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max'
-    vals = '1'
-    value_x = '(3/2) * ${U_AVG} * (1 - (y * y) / (y_max * y_max))'
-    value_y = '0'
+    symbol_names = 'y_max'
+    symbol_values = '1'
+    expression_x = '(3/2) * ${U_AVG} * (1 - (y * y) / (y_max * y_max))'
+    expression_y = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
+    expression_x = '0'
+    expression_y = '20'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_3d.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_3d.i
@@ -88,7 +88,6 @@ U_AVG = 1
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_3d.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_3d.i
@@ -229,17 +229,17 @@ U_AVG = 1
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/kernel_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/kernel_method/hunt.i
@@ -239,17 +239,17 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/kernel_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/kernel_method/hunt.i
@@ -95,7 +95,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/kernel_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/kernel_method/shercliff.i
@@ -95,7 +95,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/kernel_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/kernel_method/shercliff.i
@@ -233,17 +233,17 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
@@ -242,17 +242,17 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
@@ -95,7 +95,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/nonuniform_B.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/nonuniform_B.i
@@ -195,15 +195,15 @@ scaled_u_avg = ${fparse Re / (scaled_diameter * scaled_dens / scaled_dyn_visc)}
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '${scaled_u_avg}'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '${scaled_u_avg}'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '0'
-    value_z = '${scaled_B_max}*pow((1.0 + exp(${exp_factor}*y*${length_scaling_factor})), ${power_exp})'
+    expression_x = '0'
+    expression_y = '0'
+    expression_z = '${scaled_B_max}*pow((1.0 + exp(${exp_factor}*y*${length_scaling_factor})), ${power_exp})'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
@@ -236,17 +236,17 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
@@ -95,7 +95,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
@@ -255,17 +255,17 @@ nodetol = 1e-12
 [Functions]
   [velocityFunction]
     type = ParsedVectorFunction
-    vars = 'y_max z_max'
-    vals = '1     1'
-    value_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
-    value_y = '0'
-    value_z = '0'
+    symbol_names = 'y_max z_max'
+    symbol_values = '1     1'
+    expression_x = '(9/4) * ${U_AVG} * (1 - (y * y) / (y_max * y_max)) * (1 - (z * z) / (z_max * z_max))'
+    expression_y = '0'
+    expression_z = '0'
   []
   [magneticFieldFunction]
     type = ParsedVectorFunction
-    value_x = '0'
-    value_y = '20'
-    value_z = '0'
+    expression_x = '0'
+    expression_y = '20'
+    expression_z = '0'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
@@ -97,7 +97,6 @@ nodetol = 1e-12
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'bottom top'
-    show_info = true
   []
   [centre_node]
     type = BoundingBoxNodeSetGenerator


### PR DESCRIPTION
MHD examples used deprecated notation for functions (vals changed to symbol_values, vars to symbol_names and value_{x,y,z} to expression_{x,y,z}. These have been updated to use the new notation, removing the deprecated warnings.

Additionally, mesh show_info output has been removed from the examples to clean up the output.