### PR TITLE
Fix build - rewrite IRMINSAD materials based on updated MOOSE INSAD materials

### DIFF
--- a/include/materials/IRMINSADMaterial.h
+++ b/include/materials/IRMINSADMaterial.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Material.h"
+#include "NSEnums.h"
 
 class INSADObjectTracker;
 
@@ -19,11 +20,6 @@ public:
 
 protected:
   virtual void computeQpProperties() override;
-
-  /**
-   * compute the strong form corresponding to RZ pieces of the viscous term
-   */
-  void viscousTermRZ();
 
   /// velocity
   const ADVectorVariableValue & _velocity;
@@ -58,10 +54,6 @@ protected:
   /// Strong residual corresponding to the momentum advective term
   ADMaterialProperty<RealVectorValue> & _advective_strong_residual;
 
-  /// Strong residual corresponding to the momentum viscous term. This is only used by stabilization
-  /// kernels
-  ADMaterialProperty<RealVectorValue> & _viscous_strong_residual;
-
   /// Strong residual corresponding to the momentum electrostatic Lorentz force term
   ADMaterialProperty<RealVectorValue> & _lorentz_electrostatic_strong_residual; // IRM
 
@@ -79,6 +71,15 @@ protected:
 
   /// Strong residual corresponding to coupled force term
   ADMaterialProperty<RealVectorValue> & _coupled_force_strong_residual;
+
+  /// The mesh velocity
+  ADMaterialProperty<RealVectorValue> & _mesh_velocity;
+
+  /// The relative velocity, e.g. velocity - mesh_velocity
+  ADMaterialProperty<RealVectorValue> & _relative_velocity;
+
+  /// Strong residual corresponding to advected mesh term
+  ADMaterialProperty<RealVectorValue> & _advected_mesh_strong_residual;
 
   // /// Future addition pending addition of INSADMMSKernel.
   // /// Strong residual corresponding to the mms function term
@@ -124,7 +125,7 @@ protected:
   const MaterialProperty<Real> * _ref_temp;
 
   /// The viscous form of the equations. This is either "laplace" or "traction"
-  std::string _viscous_form;
+  NS::ViscousForm _viscous_form;
 
   /// The gravity vector
   RealVectorValue _gravity_vector;
@@ -134,4 +135,23 @@ protected:
 
   /// optional vector function(s)
   std::vector<const Function *> _coupled_force_vector_function;
+
+  /// Whether we have mesh convection
+  bool _has_advected_mesh;
+
+  /// The time derivative with respect to x-displacement
+  const ADVariableValue * _disp_x_dot;
+
+  /// The time derivative with respect to y-displacement
+  const ADVariableValue * _disp_y_dot;
+
+  /// The time derivative with respect to z-displacement
+  const ADVariableValue * _disp_z_dot;
+
+  unsigned int _disp_x_num = libMesh::invalid_uint;
+  unsigned int _disp_y_num = libMesh::invalid_uint;
+  unsigned int _disp_z_num = libMesh::invalid_uint;
+  unsigned int _disp_x_sys_num = libMesh::invalid_uint;
+  unsigned int _disp_y_sys_num = libMesh::invalid_uint;
+  unsigned int _disp_z_sys_num = libMesh::invalid_uint;
 };

--- a/include/materials/IRMINSADTauMaterial.h
+++ b/include/materials/IRMINSADTauMaterial.h
@@ -7,15 +7,16 @@
 #include "MooseArray.h"
 #include "IRMINSADMaterial.h"
 #include "NavierStokesMethods.h"
+#include "Assembly.h"
+#include "MooseVariableFE.h"
+#include "MooseMesh.h"
 
 #include "libmesh/elem.h"
+#include "libmesh/node.h"
+#include "libmesh/fe_type.h"
 
 #include <vector>
 
-/**
- * This material class computes the stabilisation parameter tau
- * for use in pressure-stabilized and streamline-upwind kernels.
- */
 class IRMINSADMaterial;
 
 template <typename T>
@@ -29,37 +30,100 @@ public:
 protected:
   virtual void computeProperties() override;
   virtual void computeQpProperties() override;
+
+  /**
+   * Compute the maximum dimension of the current element
+   */
   void computeHMax();
+
+  /**
+   * Compute the viscous strong residual
+   */
+  void computeViscousStrongResidual();
+
+  /**
+   * Compute the strong form corresponding to RZ pieces of the viscous term
+   */
+  void viscousTermRZ();
+
+  /**
+   * Whether to seed with respect to velocity derivatives
+   */
+  bool doVelocityDerivatives() const;
 
   const Real _alpha;
   ADMaterialProperty<Real> & _tau;
+
+  /// Strong residual corresponding to the momentum viscous term. This is only used by stabilization
+  /// kernels
+  ADMaterialProperty<RealVectorValue> & _viscous_strong_residual;
 
   /// The strong residual of the momentum equation
   ADMaterialProperty<RealVectorValue> & _momentum_strong_residual;
 
   ADReal _hmax;
 
+  /// The velocity variable
+  const VectorMooseVariable * const _velocity_var;
+
+  /// A scalar Lagrange FE data member to compute the velocity second derivatives since
+  /// they're currently not supported for vector FE types
+  const FEBase * const & _scalar_lagrange_fe;
+
+  /// Containers to hold the matrix of second spatial derivatives of velocity
+  std::vector<ADRealTensorValue> _d2u;
+  std::vector<ADRealTensorValue> _d2v;
+  std::vector<ADRealTensorValue> _d2w;
+
+  /// The velocity variable number
+  const unsigned int _vel_number;
+
+  /// The velocity system number
+  const unsigned int _vel_sys_number;
+
+  /// The speed of the medium. This is the norm of the relative velocity, e.g. the velocity minus
+  /// the mesh velocity, at the current _qp
+  ADReal _speed;
+
+  using T::_ad_q_point;
+  using T::_advected_mesh_strong_residual;
   using T::_advective_strong_residual;
+  using T::_assembly;
   using T::_boussinesq_strong_residual;
   using T::_coord_sys;
   using T::_coupled_force_strong_residual;
   using T::_current_elem;
-  using T::_displacements;
+  using T::_disp_x_num;
+  using T::_disp_x_sys_num;
+  using T::_disp_y_num;
+  using T::_disp_y_sys_num;
+  using T::_disp_z_num;
+  using T::_disp_z_sys_num;
   using T::_dt;
   using T::_fe_problem;
   using T::_grad_p;
+  using T::_grad_velocity;
   using T::_gravity_strong_residual;
+  using T::_has_advected_mesh;
   using T::_has_boussinesq;
   using T::_has_coupled_force;
   using T::_has_gravity;
   using T::_has_transient;
+  using T::_mesh;
   using T::_mu;
   using T::_object_tracker;
+  using T::_q_point;
   using T::_qp;
+  using T::_qrule;
+  using T::_relative_velocity;
   using T::_rho;
+  using T::_rz_axial_coord;
+  using T::_rz_radial_coord;
   using T::_td_strong_residual;
+  using T::_use_displaced_mesh;
   using T::_velocity;
-  using T::_viscous_strong_residual;
+  using T::_viscous_form;
+  using T::getVectorVar;
   using T::_lorentz_electrostatic_strong_residual;
   using T::_lorentz_flow_strong_residual;
 };
@@ -82,36 +146,59 @@ IRMINSADTauMaterialTempl<T>::IRMINSADTauMaterialTempl(const InputParameters & pa
   : T(parameters),
     _alpha(this->template getParam<Real>("alpha")),
     _tau(this->template declareADProperty<Real>("tau")),
+    _viscous_strong_residual(
+        this->template declareADProperty<RealVectorValue>("viscous_strong_residual")),
     _momentum_strong_residual(
-        this->template declareADProperty<RealVectorValue>("momentum_strong_residual"))
+        this->template declareADProperty<RealVectorValue>("momentum_strong_residual")),
+    _velocity_var(getVectorVar("velocity", 0)),
+    _scalar_lagrange_fe(
+        _assembly.getFE(FEType(_velocity_var->feType().order, LAGRANGE), _mesh.dimension())),
+    _vel_number(_velocity_var->number()),
+    _vel_sys_number(_velocity_var->sys().number())
 {
+  _scalar_lagrange_fe->get_d2phi();
+}
+
+template <typename T>
+bool
+IRMINSADTauMaterialTempl<T>::doVelocityDerivatives() const
+{
+  return ADReal::do_derivatives &&
+         (_vel_sys_number == _fe_problem.currentNonlinearSystem().number());
 }
 
 template <typename T>
 void
 IRMINSADTauMaterialTempl<T>::computeHMax()
 {
-  if (!_displacements.size())
+  if (_disp_x_num == libMesh::invalid_uint || !ADReal::do_derivatives)
   {
     _hmax = _current_elem->hmax();
     return;
   }
 
   _hmax = 0;
+  std::array<unsigned int, 3> disps = {_disp_x_num, _disp_y_num, _disp_z_num};
+  std::array<unsigned int, 3> disp_sys_nums = {_disp_x_sys_num, _disp_y_sys_num, _disp_z_sys_num};
 
   for (unsigned int n_outer = 0; n_outer < _current_elem->n_vertices(); n_outer++)
     for (unsigned int n_inner = n_outer + 1; n_inner < _current_elem->n_vertices(); n_inner++)
     {
       VectorValue<DualReal> diff = (_current_elem->point(n_outer) - _current_elem->point(n_inner));
-      unsigned dimension = 0;
-      for (const auto & disp_num : _displacements)
+      for (const auto i : index_range(disps))
       {
-        diff(dimension)
-            .derivatives()[disp_num * _fe_problem.getNonlinearSystemBase().getMaxVarNDofsPerElem() +
-                           n_outer] = 1.;
-        diff(dimension++)
-            .derivatives()[disp_num * _fe_problem.getNonlinearSystemBase().getMaxVarNDofsPerElem() +
-                           n_inner] = -1.;
+        const auto disp_num = disps[i];
+        if (disp_num == libMesh::invalid_uint)
+          continue;
+        const auto sys_num = disp_sys_nums[i];
+
+        // Here we insert derivatives of the difference in nodal positions with respect to the
+        // displacement degrees of freedom. From above, diff = outer_node_position -
+        // inner_node_position
+        diff(i).derivatives().insert(
+            _current_elem->node_ref(n_outer).dof_number(sys_num, disp_num, 0)) = 1.;
+        diff(i).derivatives().insert(
+            _current_elem->node_ref(n_inner).dof_number(sys_num, disp_num, 0)) = -1.;
       }
 
       _hmax = std::max(_hmax, diff.norm_sq());
@@ -125,8 +212,117 @@ void
 IRMINSADTauMaterialTempl<T>::computeProperties()
 {
   computeHMax();
+  computeViscousStrongResidual();
 
   T::computeProperties();
+}
+
+template <typename T>
+void
+IRMINSADTauMaterialTempl<T>::computeViscousStrongResidual()
+{
+  auto resize_and_zero = [this](auto & d2vel)
+  {
+    d2vel.resize(_qrule->n_points());
+    for (auto & d2qp : d2vel)
+      d2qp = 0;
+  };
+  resize_and_zero(_d2u);
+  resize_and_zero(_d2v);
+  resize_and_zero(_d2w);
+
+  auto get_d2 = [this](const auto i) -> std::vector<ADRealTensorValue> &
+  {
+    switch (i)
+    {
+      case 0:
+        return _d2u;
+      case 1:
+        return _d2v;
+      case 2:
+        return _d2w;
+      default:
+        mooseError("invalid value of 'i'");
+    }
+  };
+
+  // libMesh does not yet have the capability for computing second order spatial derivatives of
+  // vector bases. Lacking that capability, we can compute the second order spatial derivatives "by
+  // hand" using the scalar field version of the vector basis, e.g. LAGRANGE instead of
+  // LAGRANGE_VEC. Adding this implementation allows us to be fully consistent with results from a
+  // scalar velocity field component implementation of Navier-Stokes
+  const auto & vel_dof_indices = _velocity_var->dofIndices();
+  for (const auto i : index_range(vel_dof_indices))
+  {
+    // This may not work if the element and spatial dimensions are different
+    mooseAssert(_current_elem->dim() == _mesh.dimension(),
+                "Below logic only applicable if element and mesh dimension are the same");
+    const auto dimensional_component = i % _mesh.dimension();
+    auto & d2vel = get_d2(dimensional_component);
+    const auto dof_index = vel_dof_indices[i];
+    ADReal dof_value = (*_velocity_var->sys().currentSolution())(dof_index);
+    if (doVelocityDerivatives())
+      dof_value.derivatives().insert(dof_index) = 1;
+    const auto scalar_i_component = i / _mesh.dimension();
+    for (const auto qp : make_range(_qrule->n_points()))
+      d2vel[qp] += dof_value * _scalar_lagrange_fe->get_d2phi()[scalar_i_component][qp];
+  }
+
+  // Now that we have the second order spatial derivatives of velocity, we can compute the strong
+  // form of the viscous residual for use in our stabilization calculations
+  for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
+  {
+    _viscous_strong_residual[_qp](0) = -_mu[_qp] * _d2u[_qp].tr();
+    _viscous_strong_residual[_qp](1) =
+        _mesh.dimension() >= 2 ? -_mu[_qp] * _d2v[_qp].tr() : ADReal(0);
+    _viscous_strong_residual[_qp](2) =
+        _mesh.dimension() == 3 ? -_mu[_qp] * _d2w[_qp].tr() : ADReal(0);
+    if (_viscous_form == NS::ViscousForm::Traction)
+    {
+      _viscous_strong_residual[_qp] -= _mu[_qp] * _d2u[_qp].row(0);
+      if (_mesh.dimension() >= 2)
+        _viscous_strong_residual[_qp] -= _mu[_qp] * _d2v[_qp].row(1);
+      if (_mesh.dimension() == 3)
+        _viscous_strong_residual[_qp] -= _mu[_qp] * _d2w[_qp].row(2);
+    }
+    if (_coord_sys == Moose::COORD_RZ)
+      viscousTermRZ();
+  }
+}
+
+template <typename T>
+void
+IRMINSADTauMaterialTempl<T>::viscousTermRZ()
+{
+  // To understand the code immediately below, visit
+  // https://en.wikipedia.org/wiki/Del_in_cylindrical_and_spherical_coordinates.
+  // The u_r / r^2 term comes from the vector Laplacian. The -du_i/dr * 1/r term comes from
+  // the scalar Laplacian. The scalar Laplacian in axisymmetric cylindrical coordinates is
+  // equivalent to the Cartesian Laplacian plus a 1/r * du_i/dr term. And of course we are
+  // applying a minus sign here because the strong form is -\nabala^2 * \vec{u}
+  //
+  // Another note: libMesh implements grad(v) as dvi/dxj
+
+  const auto r = _ad_q_point[_qp](_rz_radial_coord);
+
+  if (_viscous_form == NS::ViscousForm::Laplace)
+    _viscous_strong_residual[_qp] +=
+        // u_r
+        // Additional term from vector Laplacian
+        ADRealVectorValue(_mu[_qp] * (_velocity[_qp](_rz_radial_coord) / (r * r) -
+                                      // Additional term from scalar Laplacian
+                                      _grad_velocity[_qp](_rz_radial_coord, _rz_radial_coord) / r),
+                          // u_z
+                          // Additional term from scalar Laplacian
+                          -_mu[_qp] * _grad_velocity[_qp](_rz_axial_coord, _rz_radial_coord) / r,
+                          0);
+  else
+    _viscous_strong_residual[_qp] +=
+        ADRealVectorValue(2. * _mu[_qp] *
+                              (_velocity[_qp](_rz_radial_coord) / (r * r) -
+                               _grad_velocity[_qp](_rz_radial_coord, _rz_radial_coord) / r),
+                          -_mu[_qp] / r * (_grad_velocity[_qp](1, 0) + _grad_velocity[_qp](0, 1)),
+                          0);
 }
 
 template <typename T>
@@ -137,18 +333,15 @@ IRMINSADTauMaterialTempl<T>::computeQpProperties()
 
   const auto nu = _mu[_qp] / _rho[_qp];
   const auto transient_part = _has_transient ? 4. / (_dt * _dt) : 0.;
-  const auto speed = NS::computeSpeed(_velocity[_qp]);
-  _tau[_qp] = _alpha / std::sqrt(transient_part + (2. * speed / _hmax) * (2. * speed / _hmax) +
+  _speed = NS::computeSpeed(_relative_velocity[_qp]);
+  _tau[_qp] = _alpha / std::sqrt(transient_part + (2. * _speed / _hmax) * (2. * _speed / _hmax) +
                                  9. * (4. * nu / (_hmax * _hmax)) * (4. * nu / (_hmax * _hmax)));
 
-  _momentum_strong_residual[_qp] = _advective_strong_residual[_qp] + _grad_p[_qp];
+  _momentum_strong_residual[_qp] =
+      _advective_strong_residual[_qp] + _viscous_strong_residual[_qp] + _grad_p[_qp];
 
-  _momentum_strong_residual[_qp] += _lorentz_electrostatic_strong_residual[_qp] + _lorentz_flow_strong_residual[_qp]; // IRM
-
-  // Since we can't current compute vector Laplacians we only have strong residual contributions
-  // from the viscous term in the RZ coordinate system
-  if (_coord_sys == Moose::COORD_RZ)
-    _momentum_strong_residual[_qp] += _viscous_strong_residual[_qp];
+  _momentum_strong_residual[_qp] += 
+      _lorentz_electrostatic_strong_residual[_qp] + _lorentz_flow_strong_residual[_qp]; // IRM
 
   if (_has_transient)
     _momentum_strong_residual[_qp] += _td_strong_residual[_qp];
@@ -158,6 +351,9 @@ IRMINSADTauMaterialTempl<T>::computeQpProperties()
 
   if (_has_boussinesq)
     _momentum_strong_residual[_qp] += _boussinesq_strong_residual[_qp];
+
+  if (_has_advected_mesh)
+    _momentum_strong_residual[_qp] += _advected_mesh_strong_residual[_qp];
 
   if (_has_coupled_force)
     _momentum_strong_residual[_qp] += _coupled_force_strong_residual[_qp];

--- a/src/materials/IRMINSADMaterial.C
+++ b/src/materials/IRMINSADMaterial.C
@@ -3,6 +3,7 @@
 #include "Assembly.h"
 #include "INSADObjectTracker.h"
 #include "FEProblemBase.h"
+#include "NonlinearSystemBase.h"
 #include "NS.h"
 
 registerMooseObject("ProteusApp", IRMINSADMaterial);
@@ -36,7 +37,6 @@ IRMINSADMaterial::IRMINSADMaterial(const InputParameters & parameters)
     _velocity_dot(nullptr),
     _mass_strong_residual(declareADProperty<Real>("mass_strong_residual")),
     _advective_strong_residual(declareADProperty<RealVectorValue>("advective_strong_residual")),
-    _viscous_strong_residual(declareADProperty<RealVectorValue>("viscous_strong_residual")),
     _lorentz_electrostatic_strong_residual(declareADProperty<RealVectorValue>("lorentz_electrostatic_strong_residual")), // IRM
     _lorentz_flow_strong_residual(declareADProperty<RealVectorValue>("lorentz_flow_strong_residual")), // IRM
     // We have to declare the below strong residuals for integrity check purposes even though we may
@@ -48,6 +48,10 @@ IRMINSADMaterial::IRMINSADMaterial(const InputParameters & parameters)
     _boussinesq_strong_residual(declareADProperty<RealVectorValue>("boussinesq_strong_residual")),
     _coupled_force_strong_residual(
         declareADProperty<RealVectorValue>("coupled_force_strong_residual")),
+    _mesh_velocity(declareADProperty<RealVectorValue>("mesh_velocity")),
+    _relative_velocity(declareADProperty<RealVectorValue>("relative_velocity")),
+    _advected_mesh_strong_residual(
+        declareADProperty<RealVectorValue>("advected_mesh_strong_residual")),
     // _mms_function_strong_residual(declareProperty<RealVectorValue>("mms_function_strong_residual")),
     _use_displaced_mesh(getParam<bool>("use_displaced_mesh")),
     _ad_q_point(_bnd ? _assembly.adQPointsFace() : _assembly.adQPoints()),
@@ -85,11 +89,10 @@ IRMINSADMaterial::subdomainSetup()
     // safe for dependencies
     _boussinesq_alpha = &_material_data.getProperty<Real, true>(
         _object_tracker->get<MaterialPropertyName>("alpha", _current_subdomain_id), 0, *this);
-    _temperature =
-        &_subproblem
-             .getStandardVariable(
-                 _tid, _object_tracker->get<std::string>("temperature", _current_subdomain_id))
-             .adSln();
+    auto & temp_var = _subproblem.getStandardVariable(
+        _tid, _object_tracker->get<std::string>("temperature", _current_subdomain_id));
+    addMooseVariableDependency(&temp_var);
+    _temperature = &temp_var.adSln();
     _ref_temp = &_material_data.getProperty<Real, false>(
         _object_tracker->get<MaterialPropertyName>("ref_temp", _current_subdomain_id), 0, *this);
   }
@@ -106,8 +109,64 @@ IRMINSADMaterial::subdomainSetup()
   else
     _gravity_vector = 0;
 
-  _viscous_form = static_cast<std::string>(
-      _object_tracker->get<MooseEnum>("viscous_form", _current_subdomain_id));
+  // Setup data for Arbitrary Lagrangian Eulerian (ALE) simulations in which the simulation domain
+  // is displacing. We will need to subtract the mesh velocity from the velocity solution in order
+  // to get the correct material velocity for the momentum convection term.
+  if ((_has_advected_mesh = _object_tracker->get<bool>("has_advected_mesh", _current_subdomain_id)))
+  {
+    auto & disp_x = _subproblem.getStandardVariable(
+        _tid, _object_tracker->get<VariableName>("disp_x", _current_subdomain_id));
+    addMooseVariableDependency(&disp_x);
+    _disp_x_dot = &disp_x.adUDot();
+    _disp_x_sys_num = disp_x.sys().number();
+    _disp_x_num = (disp_x.kind() == Moose::VarKindType::VAR_NONLINEAR) &&
+                          (_disp_x_sys_num == _fe_problem.currentNonlinearSystem().number())
+                      ? disp_x.number()
+                      : libMesh::invalid_uint;
+    if (_object_tracker->isTrackerParamValid("disp_y", _current_subdomain_id))
+    {
+      auto & disp_y = _subproblem.getStandardVariable(
+          _tid, _object_tracker->get<VariableName>("disp_y", _current_subdomain_id));
+      addMooseVariableDependency(&disp_y);
+      _disp_y_dot = &disp_y.adUDot();
+      _disp_y_sys_num = disp_y.sys().number();
+      _disp_y_num =
+          disp_y.kind() == (Moose::VarKindType::VAR_NONLINEAR &&
+                            (_disp_y_sys_num == _fe_problem.currentNonlinearSystem().number()))
+              ? disp_y.number()
+              : libMesh::invalid_uint;
+    }
+    else
+    {
+      _disp_y_dot = nullptr;
+      _disp_y_sys_num = libMesh::invalid_uint;
+      _disp_y_num = libMesh::invalid_uint;
+    }
+    if (_object_tracker->isTrackerParamValid("disp_z", _current_subdomain_id))
+    {
+      auto & disp_z = _subproblem.getStandardVariable(
+          _tid, _object_tracker->get<VariableName>("disp_z", _current_subdomain_id));
+      addMooseVariableDependency(&disp_z);
+      _disp_z_dot = &disp_z.adUDot();
+      _disp_z_sys_num = disp_z.sys().number();
+      _disp_z_num =
+          disp_z.kind() == (Moose::VarKindType::VAR_NONLINEAR &&
+                            (_disp_z_sys_num == _fe_problem.currentNonlinearSystem().number()))
+              ? disp_z.number()
+              : libMesh::invalid_uint;
+    }
+    else
+    {
+      _disp_z_dot = nullptr;
+      _disp_z_sys_num = libMesh::invalid_uint;
+      _disp_z_num = libMesh::invalid_uint;
+    }
+  }
+  else
+    _disp_x_dot = _disp_y_dot = _disp_z_dot = nullptr;
+
+  _viscous_form = static_cast<NS::ViscousForm>(
+      int(_object_tracker->get<MooseEnum>("viscous_form", _current_subdomain_id)));
 
   if ((_has_coupled_force = _object_tracker->get<bool>("has_coupled_force", _current_subdomain_id)))
   {
@@ -147,7 +206,7 @@ IRMINSADMaterial::computeQpProperties()
   _lorentz_electrostatic_strong_residual[_qp] = _conductivity[_qp] * _grad_epot[_qp].cross(_magnetic_field[_qp]); // IRM
   auto UxB = _velocity[_qp].cross(_magnetic_field[_qp]);  // IRM
   _lorentz_flow_strong_residual[_qp] = -_conductivity[_qp] * UxB.cross(_magnetic_field[_qp]); // IRM
-
+  
   if (_has_transient)
     _td_strong_residual[_qp] = _rho[_qp] * (*_velocity_dot)[_qp];
   if (_has_gravity)
@@ -155,6 +214,19 @@ IRMINSADMaterial::computeQpProperties()
   if (_has_boussinesq)
     _boussinesq_strong_residual[_qp] = (*_boussinesq_alpha)[_qp] * _gravity_vector * _rho[_qp] *
                                        ((*_temperature)[_qp] - (*_ref_temp)[_qp]);
+  _relative_velocity[_qp] = _velocity[_qp];
+
+  if (_has_advected_mesh)
+  {
+    _mesh_velocity[_qp](0) = (*_disp_x_dot)[_qp];
+    if (_disp_y_dot)
+      _mesh_velocity[_qp](1) = (*_disp_y_dot)[_qp];
+    if (_disp_z_dot)
+      _mesh_velocity[_qp](2) = (*_disp_z_dot)[_qp];
+    _relative_velocity[_qp] -= _mesh_velocity[_qp];
+    _advected_mesh_strong_residual[_qp] = -_rho[_qp] * _grad_velocity[_qp] * _mesh_velocity[_qp];
+  }
+
   if (_has_coupled_force)
   {
     _coupled_force_strong_residual[_qp] = 0;
@@ -177,77 +249,4 @@ IRMINSADMaterial::computeQpProperties()
   // _mms_function_strong_residual[_qp] = -RealVectorValue(_x_vel_fn.value(_t, _q_point[_qp]),
   //                                                       _y_vel_fn.value(_t, _q_point[_qp]),
   //                                                       _z_vel_fn.value(_t, _q_point[_qp]));
-
-  // // The code immediately below is fictional. E.g. there is no Moose::Laplacian nor is there
-  // // currently a _second_velocity member because TypeNTensor (where N = 3 in this case) math is not
-  // // really implemented in libMesh. Hence we cannot add this strong form contribution of the viscous
-  // // term at this time. Note that for linear elements this introduces no error in the consistency of
-  // // stabilization methods, and in general for bi-linear elements, the error introduced is small
-  // _viscous_strong_residual[_qp] = -_mu[_qp] * Moose::Laplacian(_second_velocity[_qp]);
-
-  if (_coord_sys == Moose::COORD_RZ)
-    viscousTermRZ();
-}
-
-void
-IRMINSADMaterial::viscousTermRZ()
-{
-  // To understand the code immediately below, visit
-  // https://en.wikipedia.org/wiki/Del_in_cylindrical_and_spherical_coordinates.
-  // The u_r / r^2 term comes from the vector Laplacian. The -du_i/dr * 1/r term comes from
-  // the scalar Laplacian. The scalar Laplacian in axisymmetric cylindrical coordinates is
-  // equivalent to the Cartesian Laplacian plus a 1/r * du_i/dr term. And of course we are
-  // applying a minus sign here because the strong form is -\nabala^2 * \vec{u}
-  //
-  // Another note: libMesh implements grad(v) as dvi/dxj
-
-  if (_use_displaced_mesh)
-  {
-    ADReal r = _ad_q_point[_qp](_rz_radial_coord);
-
-    if (_viscous_form == "laplace")
-      _viscous_strong_residual[_qp] = ADRealVectorValue(
-          // u_r
-          // Additional term from vector Laplacian
-          _mu[_qp] * (_velocity[_qp](_rz_radial_coord) / (r * r) -
-                      // Additional term from scalar Laplacian
-                      _grad_velocity[_qp](_rz_radial_coord, _rz_radial_coord) / r),
-          // u_z
-          // Additional term from scalar Laplacian
-          -_mu[_qp] * _grad_velocity[_qp](_rz_axial_coord, _rz_radial_coord) / r,
-          0);
-    else
-      _viscous_strong_residual[_qp] =
-          ADRealVectorValue(2. * _mu[_qp] *
-                                (_velocity[_qp](_rz_radial_coord) / (r * r) -
-                                 _grad_velocity[_qp](_rz_radial_coord, _rz_radial_coord) / r),
-                            -_mu[_qp] / r * (_grad_velocity[_qp](1, 0) + _grad_velocity[_qp](0, 1)),
-                            0);
-  }
-  else
-  {
-    Real r = _q_point[_qp](_rz_radial_coord);
-    if (_viscous_form == "laplace")
-      _viscous_strong_residual[_qp] =
-          // u_r
-          // Additional term from vector Laplacian
-          ADRealVectorValue(
-              _mu[_qp] * (_velocity[_qp](_rz_radial_coord) /
-                              (_q_point[_qp](_rz_radial_coord) * _q_point[_qp](_rz_radial_coord)) -
-                          // Additional term from scalar Laplacian
-                          _grad_velocity[_qp](_rz_radial_coord, _rz_radial_coord) /
-                              _q_point[_qp](_rz_radial_coord)),
-              // u_z
-              // Additional term from scalar Laplacian
-              -_mu[_qp] * _grad_velocity[_qp](_rz_axial_coord, _rz_radial_coord) /
-                  _q_point[_qp](_rz_radial_coord),
-              0);
-    else
-      _viscous_strong_residual[_qp] =
-          ADRealVectorValue(2. * _mu[_qp] *
-                                (_velocity[_qp](_rz_radial_coord) / (r * r) -
-                                 _grad_velocity[_qp](_rz_radial_coord, _rz_radial_coord) / r),
-                            -_mu[_qp] / r * (_grad_velocity[_qp](1, 0) + _grad_velocity[_qp](0, 1)),
-                            0);
-  }
 }


### PR DESCRIPTION
Build was broken due to changes to how materials are written in MOOSE. The IRMINSAD materials were originally written by modifying MOOSE Navier-Stokes INSAD materials. These were re-written by making the same changes to the updated MOOSE Navier-Stokes INSAD materials.

This pull request resolves the broken build, however the changes to the IRMINSAD material method examples no longer converge. This will be raised as a git issue following this pull request.