### PR TITLE
CSD3 build fix  - resolve install_csd3.sh build failure due to outdated cmake

### DIFF
--- a/scripts/install_csd3.sh
+++ b/scripts/install_csd3.sh
@@ -23,6 +23,7 @@ echo "export F77=mpif77" >> $HOME/.moose_profile
 echo "export FC=mpif90" >> $HOME/.moose_profile
 echo "export MOOSE_DIR="$HOME"/moose" >> $HOME/.moose_profile
 echo "export PATH=\$PATH:"$PROTEUS_DIR >> $HOME/.moose_profile
+echo "export PATH=/home/ir-eard1/moose/petsc/arch-moose/bin/:\$PATH" >> $HOME/.moose_profile
 echo "export OMPI_MCA_mca_base_component_show_load_errors=0" >> $HOME/.moose_profile
 source $HOME/.moose_profile
 

--- a/scripts/install_csd3.sh
+++ b/scripts/install_csd3.sh
@@ -23,7 +23,7 @@ echo "export F77=mpif77" >> $HOME/.moose_profile
 echo "export FC=mpif90" >> $HOME/.moose_profile
 echo "export MOOSE_DIR="$HOME"/moose" >> $HOME/.moose_profile
 echo "export PATH=\$PATH:"$PROTEUS_DIR >> $HOME/.moose_profile
-echo "export PATH=/home/ir-eard1/moose/petsc/arch-moose/bin/:\$PATH" >> $HOME/.moose_profile
+echo "export PATH=\$MOOSE_DIR/petsc/arch-moose/bin/:\$PATH" >> $HOME/.moose_profile
 echo "export OMPI_MCA_mca_base_component_show_load_errors=0" >> $HOME/.moose_profile
 source $HOME/.moose_profile
 

--- a/scripts/install_csd3.sh
+++ b/scripts/install_csd3.sh
@@ -14,7 +14,7 @@ export PROTEUS_DIR=`pwd`
 # Make MOOSE profile
 
 echo "module purge" > $HOME/.moose_profile
-echo "module load dot slurm cmake/latest rhel7/global" >> $HOME/.moose_profile
+echo "module load dot slurm rhel7/global" >> $HOME/.moose_profile
 echo "module load git-2.31.0-gcc-5.4.0-ec3ji34 python/3.8 gcc/9 openmpi/gcc/9.3/4.0.4" >> $HOME/.moose_profile
 echo "export CC=mpicc" >> $HOME/.moose_profile
 echo "export CXX=mpicxx" >> $HOME/.moose_profile
@@ -43,7 +43,8 @@ CC=$CC CXX=$CXX F90=$F90 F77=$F77 FC=$FC \
 --CXXOPTFLAGS="-O3 -march=cascadelake -mtune=cascadelake" \
 --COPTFLAGS="-O3 -march=cascadelake -mtune=cascadelake" \
 --FOPTFLAGS="-O3 -march=cascadelake -mtune=cascadelake" \
---download-mumps=0 --download-superlu_dist=0 --with-64-bit-indices=1
+--download-mumps=0 --download-superlu_dist=0 --with-64-bit-indices=1 \
+--download-cmake
 
 # Build libMesh
 


### PR DESCRIPTION
Build on CSD3 with install_csd3.sh was failing due to using an older version of cmake (from the available modules) than required for PETSc. This issue likely arose from MOOSE updating to a more recent version of PETSc. Now cmake is built during the PETSc build process and added to the $PATH in .moose_profile (allowing this version of cmake to be used by WASP later in the build and providing an updated cmake for use in the Proteus environment).