### PR TITLE
Fix meshing & update preconditioners in MHD examples

### DIFF
--- a/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2d.i
@@ -144,8 +144,8 @@ U_AVG = 1
   solve_type = NEWTON
   l_max_its = 30
   nl_max_its = 150
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre euclid'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step3_navier_stokes_2d.i
@@ -13,6 +13,7 @@ U_AVG = 1
     ymin = 0
     ymax = 1
     bias_y = 0.8
+    boundary_name_prefix = 'meshTop'
   []
   [meshBottom]
     type = GeneratedMeshGenerator
@@ -24,12 +25,29 @@ U_AVG = 1
     ymin = -1
     ymax = 0
     bias_y = 1.25
+    boundary_name_prefix = 'meshBottom'
   []
   [meshComplete]
     type = StitchedMeshGenerator
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [meshRename]
+    type = RenameBoundaryGenerator
+    input = meshComplete
+    old_boundary = '
+      meshTop_right meshBottom_right
+      meshTop_left meshBottom_left
+      meshTop_top
+      meshBottom_bottom
+    '
+    new_boundary = '
+      right right
+      left left
+      top
+      bottom
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step5_lorentz_force_E_field.i
+++ b/examples/mhd/incompressible_inductionless/development/step5_lorentz_force_E_field.i
@@ -149,7 +149,7 @@ U_AVG = 1
   []
   [epotFunction]
     type = ParsedFunction
-    value = '20 * z'
+    expression = '20 * z'
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step6_coupled_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step6_coupled_2d.i
@@ -16,6 +16,7 @@ U_AVG = 1
     ymax = 1
     bias_y = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTop'
   []
   [meshBottom]
     type = GeneratedMeshGenerator
@@ -28,12 +29,29 @@ U_AVG = 1
     ymax = 0
     bias_y = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottom'
   []
   [meshComplete]
     type = StitchedMeshGenerator
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [meshRename]
+    type = RenameBoundaryGenerator
+    input = meshComplete
+    old_boundary = '
+      meshTop_right meshBottom_right
+      meshTop_left meshBottom_left
+      meshTop_top
+      meshBottom_bottom
+    '
+    new_boundary = '
+      right right
+      left left
+      top
+      bottom
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step6_coupled_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step6_coupled_2d.i
@@ -200,8 +200,8 @@ U_AVG = 1
   automatic_scaling = true
   l_max_its = 100
   nl_max_its = 150
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre    euclid'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/development/step6_coupled_3d.i
+++ b/examples/mhd/incompressible_inductionless/development/step6_coupled_3d.i
@@ -22,6 +22,7 @@ U_AVG = 1
     bias_y = 0.8
     bias_z = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -38,6 +39,7 @@ U_AVG = 1
     bias_y = 0.8
     bias_z = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -54,6 +56,7 @@ U_AVG = 1
     bias_y = 1.25
     bias_z = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -70,24 +73,73 @@ U_AVG = 1
     bias_y = 1.25
     bias_z = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_3d_NS_comparison.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_3d_NS_comparison.i
@@ -22,6 +22,7 @@ U_AVG = 1
     bias_y = 0.8
     bias_z = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -38,6 +39,7 @@ U_AVG = 1
     bias_y = 0.8
     bias_z = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -54,6 +56,7 @@ U_AVG = 1
     bias_y = 1.25
     bias_z = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -70,24 +73,73 @@ U_AVG = 1
     bias_y = 1.25
     bias_z = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_2d.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_2d.i
@@ -16,6 +16,7 @@ U_AVG = 1
     ymax = 1
     bias_y = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTop'
   []
   [meshBottom]
     type = GeneratedMeshGenerator
@@ -28,12 +29,29 @@ U_AVG = 1
     ymax = 0
     bias_y = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottom'
   []
   [mesh]
     type = StitchedMeshGenerator
     inputs = 'meshTop meshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [meshRename]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshTop_right meshBottom_right
+      meshTop_left meshBottom_left
+      meshTop_top
+      meshBottom_bottom
+    '
+    new_boundary = '
+      right right
+      left left
+      top
+      bottom
+    '
   []
 []
 
@@ -203,8 +221,8 @@ U_AVG = 1
   automatic_scaling = true
   l_max_its = 100
   nl_max_its = 150
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre    euclid'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_3d.i
+++ b/examples/mhd/incompressible_inductionless/development/step7_coupled_using_material_3d.i
@@ -22,6 +22,7 @@ U_AVG = 1
     bias_y = 0.8
     bias_z = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -38,6 +39,7 @@ U_AVG = 1
     bias_y = 0.8
     bias_z = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -54,6 +56,7 @@ U_AVG = 1
     bias_y = 1.25
     bias_z = 1.25
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -70,24 +73,73 @@ U_AVG = 1
     bias_y = 1.25
     bias_z = 0.8
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/kernel_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/kernel_method/hunt.i
@@ -29,6 +29,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -45,6 +46,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -61,6 +63,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -77,24 +80,73 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/kernel_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/kernel_method/shercliff.i
@@ -29,6 +29,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -45,6 +46,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -61,6 +63,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -77,24 +80,73 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
@@ -30,7 +30,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
     boundary_name_prefix = 'meshTopBack'
-    show_info = true
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -48,7 +47,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
     boundary_name_prefix = 'meshTopFront'
-    show_info = true
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -66,7 +64,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
     boundary_name_prefix = 'meshBottomBack'
-    show_info = true
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -84,14 +81,12 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
     boundary_name_prefix = 'meshBottomFront'
-    show_info = true
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
-    show_info = true
   []
   [renameMeshTop]
     type = RenameBoundaryGenerator
@@ -108,14 +103,12 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
       meshTop_left meshTop_left
       meshTop_bottom meshTop_bottom
     '
-    show_info = true
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
-    show_info = true
   []
   [renameMeshBottom]
     type = RenameBoundaryGenerator
@@ -132,14 +125,12 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
       meshBottom_left meshBottom_left
       bottom bottom
     '
-    show_info = true
   []
   [mesh]
     type = StitchedMeshGenerator
     inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
     stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
-    show_info = true
   []
   [renameMesh]
     type = RenameBoundaryGenerator
@@ -156,7 +147,6 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
       left left
       right right
     '
-    show_info = true
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/hunt.i
@@ -29,6 +29,8 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
+    show_info = true
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -45,6 +47,8 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
+    show_info = true
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -61,6 +65,8 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
+    show_info = true
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -77,24 +83,80 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
+    show_info = true
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+    show_info = true
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
+    show_info = true
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+    show_info = true
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
+    show_info = true
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+    show_info = true
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
+    show_info = true
   []
 []
 
@@ -274,7 +336,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
   l_max_its = 100
   nl_max_its = 1000
   petsc_options_iname = '-pc_type'
-  petsc_options_value = 'asm'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/validation/material_method/nonuniform_B.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/nonuniform_B.i
@@ -224,8 +224,8 @@ scaled_u_avg = ${fparse Re / (scaled_diameter * scaled_dens / scaled_dyn_visc)}
   automatic_scaling = true
   l_max_its = 100
   nl_max_its = 1000
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre    euclid'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
@@ -320,7 +320,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
   l_max_its = 100
   nl_max_its = 1000
   petsc_options_iname = '-pc_type'
-  petsc_options_value = 'asm'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff.i
@@ -29,6 +29,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -45,6 +46,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -61,6 +63,7 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -77,24 +80,73 @@ RATIO_Z_INV = ${fparse 1/RATIO_Z_FWD}
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
 []
 

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
@@ -339,7 +339,7 @@ nodetol = 1e-12
   l_max_its = 100
   nl_max_its = 1000
   petsc_options_iname = '-pc_type'
-  petsc_options_value = 'asm'
+  petsc_options_value = 'ilu'
 []
 
 [Outputs]

--- a/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
+++ b/examples/mhd/incompressible_inductionless/validation/material_method/shercliff_pinned.i
@@ -31,6 +31,7 @@ nodetol = 1e-12
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopBack'
   []
   [meshTopFront]
     type = GeneratedMeshGenerator
@@ -47,6 +48,7 @@ nodetol = 1e-12
     bias_y = ${RATIO_Y_INV}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshTopFront'
   []
   [meshBottomBack]
     type = GeneratedMeshGenerator
@@ -63,6 +65,7 @@ nodetol = 1e-12
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_FWD}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomBack'
   []
   [meshBottomFront]
     type = GeneratedMeshGenerator
@@ -79,29 +82,78 @@ nodetol = 1e-12
     bias_y = ${RATIO_Y_FWD}
     bias_z = ${RATIO_Z_INV}
     elem_type = ${ELEMENT_TYPE}
+    boundary_name_prefix = 'meshBottomFront'
   []
   [meshTop]
     type = StitchedMeshGenerator
     inputs = 'meshTopBack meshTopFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshTopBack_front meshTopFront_back'
+  []
+  [renameMeshTop]
+    type = RenameBoundaryGenerator
+    input = meshTop
+    old_boundary = '
+      meshTopBack_top meshTopFront_top
+      meshTopBack_right meshTopFront_right
+      meshTopBack_left meshTopFront_left
+      meshTopBack_bottom meshTopFront_bottom
+    '
+    new_boundary = '
+      top top
+      meshTop_right meshTop_right
+      meshTop_left meshTop_left
+      meshTop_bottom meshTop_bottom
+    '
   []
   [meshBottom]
     type = StitchedMeshGenerator
     inputs = 'meshBottomBack meshBottomFront'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'front back'
+    stitch_boundaries_pairs = 'meshBottomBack_front meshBottomFront_back'
+  []
+  [renameMeshBottom]
+    type = RenameBoundaryGenerator
+    input = meshBottom
+    old_boundary = '
+      meshBottomBack_top meshBottomFront_top
+      meshBottomBack_right meshBottomFront_right
+      meshBottomBack_left meshBottomFront_left
+      meshBottomBack_bottom meshBottomFront_bottom
+    '
+    new_boundary = '
+      meshBottom_top meshBottom_top
+      meshBottom_right meshBottom_right
+      meshBottom_left meshBottom_left
+      bottom bottom
+    '
   []
   [mesh]
     type = StitchedMeshGenerator
-    inputs = 'meshTop meshBottom'
+    inputs = 'renameMeshTop renameMeshBottom'
     clear_stitched_boundary_ids = true
-    stitch_boundaries_pairs = 'bottom top'
+    stitch_boundaries_pairs = 'meshTop_bottom meshBottom_top'
+  []
+  [renameMesh]
+    type = RenameBoundaryGenerator
+    input = mesh
+    old_boundary = '
+      meshBottomFront_front meshTopFront_front
+      meshBottomBack_back meshTopBack_back
+      meshBottom_left meshTop_left
+      meshBottom_right meshTop_right
+    '
+    new_boundary = '
+      front front
+      back back
+      left left
+      right right
+    '
   []
   [centre_node]
     type = BoundingBoxNodeSetGenerator
     new_boundary = 'pinned_node'
-    input = mesh
+    input = renameMesh
     bottom_left =  '${fparse (0 - nodetol)}
                     ${fparse (0 - nodetol)}
                     ${fparse (0 - nodetol)}'


### PR DESCRIPTION
The MHD IRMINSAD materials were previously updated to fix an issue that was breaking Proteus compilation. After making this fix, testing the MHD examples highlighted that these no longer converged as before with the preconditioners set.

This has been investigated and found to be due to MOOSE treating boundaries after the StitchedMeshGenerator stage differently - previously the multiple boundaries with the same names were merged implicitly, whereas now they must be manually merged with RenameBoundaryGenerator blocks. These have now been implemented in all MHD examples involving StitchedMeshGenerator blocks.

Some of the MHD examples previously utilised the hypre euclid preconditioner - these failed to run as hypre euclid no longer supports 64-bit indices and so has been replaced with ilu in these cases.

Additionally, ilu was identified to solve the material method examples faster than previous preconditioner tests had found, so this was set as the default in these examples.