### PR TITLE
Implementation of time averaging Aux kernels

### DIFF
--- a/examples/time_averaging/compare_averages.py
+++ b/examples/time_averaging/compare_averages.py
@@ -1,0 +1,76 @@
+"""compare_averages.py
+Python script to verify the time averaging in the TimeAverageAux
+class.
+
+Equation being solved
+   df/dt = -1
+Initial conditions
+  f(0) = x + y + z
+Analytical solution
+  f = f(0) - t
+Analytical mean
+  \bar{f} = \frac{1}{T}\int_0^T f(0) - t dt = f(0) - T/2
+Analytical variance
+  \overline{f^2} = \frac{1}{T}\int_0^T (f(0) - t)^2 dt = f(0)^2 - f(0)T  + T^2/3
+"""
+
+# requires vtk
+import vtk
+from vtkmodules.numpy_interface.dataset_adapter import VTKArray
+
+
+def main():
+    # read data using the vtkExodusIIReader
+    reader = vtk.vtkExodusIIReader()
+    reader.SetFileName("scalar_time_averaging_out.e")
+    reader.UpdateInformation()
+
+    # Use the last time step
+    tstep = reader.GetNumberOfTimeSteps() - 1
+    reader.SetTimeStep(tstep)
+
+    # Extract the avg_mean variable
+    reader.SetPointResultArrayStatus("avg_mean", 1)
+    reader.SetPointResultArrayStatus("avg_var", 1)
+    reader.Update()  # Read file
+
+    # Extract Unstructured grid
+    multiblock: vtk.vtkMultiBlockDataSet = reader.GetOutputDataObject(0)
+    data: vtk.vtkUnstructuredGrid = multiblock.GetBlock(0).GetBlock(0)
+
+    # Get the average and variance array and coordinates and wrap
+    avg_mean = VTKArray(data.GetPointData().GetAbstractArray("avg_mean"))
+    avg_var = VTKArray(data.GetPointData().GetAbstractArray("avg_var"))
+    coords = VTKArray(data.GetPoints().GetData())
+
+    # Determine time dynamically
+    pipeline = vtk.vtkStreamingDemandDrivenPipeline()
+    key = pipeline.TIME_STEPS()
+    vtkinfo = reader.GetOutputInformation(0)
+    time = vtkinfo.Get(key, tstep)
+
+    # use same initial conditions as MOOSE
+    x, y, z = coords.T
+    f0 = x + y + z
+
+    # analytical means and variances
+    f_bar = f0 - 0.5 * time
+    f_var = f0 * f0 - f0 * time + time * time / 3.0
+
+    # output absolute and relative error for the mean
+    abs_error = abs(f_bar - avg_mean)
+    rel_error = abs_error[f_bar != 0] / f_bar[f_bar != 0]
+    print("avg_mean:")
+    print("\tRelative error: ", rel_error.max())
+    print("\tAbsolute error: ", abs_error.max())
+
+    # output absolute and relative error for the variance
+    abs_error = abs(f_var - avg_var)
+    rel_error = abs_error / f_var
+    print("avg_var:")
+    print("\tRelative error: ", rel_error.max())
+    print("\tAbsolute error: ", abs_error.max())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/time_averaging/compare_averages.py
+++ b/examples/time_averaging/compare_averages.py
@@ -1,6 +1,4 @@
-"""compare_averages.py
-Python script to verify the time averaging in the TimeAverageAux
-class.
+r"""Script to verify the time averaging in the TimeAverageAux class.
 
 Equation being solved
    df/dt = -1
@@ -11,7 +9,7 @@ Analytical solution
 Analytical mean
   \bar{f} = \frac{1}{T}\int_0^T f(0) - t dt = f(0) - T/2
 Analytical variance
-  \overline{f^2} = \frac{1}{T}\int_0^T (f(0) - t)^2 dt = f(0)^2 - f(0)T  + T^2/3
+  \overline{f^2} = \frac{1}{T}\int_0^T (f(0) - t)^2 dt = f(0)^2 - f(0)T + T^2/3
 """
 
 # requires vtk
@@ -20,6 +18,7 @@ from vtkmodules.numpy_interface.dataset_adapter import VTKArray
 
 
 def main():
+    """Test the outputs of the TimeAverageAux class."""
     # read data using the vtkExodusIIReader
     reader = vtk.vtkExodusIIReader()
     reader.SetFileName("scalar_time_averaging_out.e")

--- a/examples/time_averaging/scalar_time_averaging.i
+++ b/examples/time_averaging/scalar_time_averaging.i
@@ -1,0 +1,87 @@
+# Simple example of the TimeAverageAux
+# ------------------------------------
+# The example can be easily modified to test VectorTimeAverageAux by
+# replacing the Kernels, Variables, ICs, AuxVariables and AuxKernels
+# with the vector counterparts.
+
+[Mesh]
+  [gmg]
+    type=GeneratedMeshGenerator
+    dim=3
+    nx = 10
+    ny = 1
+    nz = 1
+  []
+[]
+
+[Kernels]
+  [time_deriv]
+    type=TimeDerivative
+    variable=var1
+  []
+  [bodyf]
+    type=BodyForce
+    variable=var1
+    function='-1'
+  []
+[]
+
+
+[ICs]
+  [ics]
+    type=FunctionIC
+    variable=var1
+    function='x + y + z'
+  []
+[]
+
+[BCs]
+  [all]
+    type=NeumannBC
+    boundary = '0 1 2 3 4 5'
+    variable=var1
+    value=0
+  []
+[]
+
+[Variables]
+  [var1]
+    order=FIRST
+    family =LAGRANGE
+  []
+[]
+[AuxVariables]
+  [avg_mean]
+    order=FIRST
+    family =LAGRANGE
+  []
+  [avg_var]
+    order=FIRST
+    family =LAGRANGE
+  []
+[]
+
+[AuxKernels]
+  [mean]
+    type=TimeAverageAux
+    variable=avg_mean
+    scalars=var1
+    execute_on=TIMESTEP_END
+  []
+  [variance]
+    type=TimeAverageAux
+    variable=avg_var
+    scalars='var1 var1'
+    execute_on=TIMESTEP_END
+  []
+[]
+
+[Executioner]
+  type=Transient
+  num_steps=1000
+  dt=0.001
+[]
+
+[Outputs]
+  exodus=true
+[]

--- a/include/auxkernels/TimeAverageAux.h
+++ b/include/auxkernels/TimeAverageAux.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "AuxKernel.h"
+#include "MooseArray.h"
+#include "MooseTypes.h"
+
+class TimeAverageAux : public AuxKernel
+{
+public:
+  static InputParameters validParams();
+
+  TimeAverageAux(const InputParameters & parameters);
+
+protected:
+  Real computeValue() override;
+  void initialSetup() override;
+  void timestepSetup() override;
+
+  std::vector<const VariableValue*> _scalars;
+  std::vector<const VariableValue*> _scalars_old;
+
+  VariableValue _average;
+  VariableValue _average_old;
+
+};

--- a/include/auxkernels/TimeAverageAux.h
+++ b/include/auxkernels/TimeAverageAux.h
@@ -13,13 +13,8 @@ public:
 
 protected:
   Real computeValue() override;
-  void initialSetup() override;
-  void timestepSetup() override;
 
   std::vector<const VariableValue*> _scalars;
   std::vector<const VariableValue*> _scalars_old;
-
-  VariableValue _average;
-  VariableValue _average_old;
 
 };

--- a/include/auxkernels/VectorTimeAverageAux.h
+++ b/include/auxkernels/VectorTimeAverageAux.h
@@ -13,15 +13,10 @@ public:
 
 protected:
   RealVectorValue computeValue() override;
-  void initialSetup() override;
-  void timestepSetup() override;
 
   std::vector<const VariableValue*> _scalars;
   std::vector<const VariableValue*> _scalars_old;
 
   std::vector<const VectorVariableValue*> _vectors;
   std::vector<const VectorVariableValue*> _vectors_old;
-
-  VectorVariableValue _average;
-  VectorVariableValue _average_old;
 };

--- a/include/auxkernels/VectorTimeAverageAux.h
+++ b/include/auxkernels/VectorTimeAverageAux.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "AuxKernel.h"
+#include "MooseArray.h"
+#include "MooseTypes.h"
+
+class VectorTimeAverageAux : public VectorAuxKernel
+{
+public:
+  static InputParameters validParams();
+
+  VectorTimeAverageAux(const InputParameters & parameters);
+
+protected:
+  RealVectorValue computeValue() override;
+  void initialSetup() override;
+  void timestepSetup() override;
+
+  std::vector<const VariableValue*> _scalars;
+  std::vector<const VariableValue*> _scalars_old;
+
+  std::vector<const VectorVariableValue*> _vectors;
+  std::vector<const VectorVariableValue*> _vectors_old;
+
+  VectorVariableValue _average;
+  VectorVariableValue _average_old;
+};

--- a/src/auxkernels/TimeAverageAux.C
+++ b/src/auxkernels/TimeAverageAux.C
@@ -10,7 +10,7 @@ TimeAverageAux::validParams()
   params.addClassDescription("AuxKernel that performs time averaging of variables.");
   params.addRequiredCoupledVar("scalars",
                        "Scalar variables to be averaged. If multiple scalars are "
-                       "given the average of their product is given");
+                       "given the average of their product is given.");
   return params;
 }
 TimeAverageAux::TimeAverageAux(const InputParameters & parameters)
@@ -24,14 +24,14 @@ TimeAverageAux::TimeAverageAux(const InputParameters & parameters)
 Real TimeAverageAux::computeValue()
 {
   const Real coeff =  _dt/_t;
-  Real val =1., val_old=1.;
+  Real val = 1., val_old = 1.;
 
   // compute value and old value using product of input scalars
   for (auto& v: _scalars){
     val *= (*v)[_qp];
   }
   for (auto& v: _scalars_old){
-    val_old*= (*v)[_qp];
+    val_old *= (*v)[_qp];
   }
 
   // Add weighted contribution of current step. Average contribution

--- a/src/auxkernels/TimeAverageAux.C
+++ b/src/auxkernels/TimeAverageAux.C
@@ -1,0 +1,58 @@
+#include "TimeAverageAux.h"
+
+registerMooseObject("ProteusApp", TimeAverageAux);
+
+InputParameters
+TimeAverageAux::validParams()
+{
+  InputParameters params = AuxKernel::validParams();
+
+  params.addClassDescription("AuxKernel that performs time averaging of variables."
+                             "");
+  params.addRequiredCoupledVar("scalars",
+                       "Scalar variables to be averaged");
+  return params;
+}
+TimeAverageAux::TimeAverageAux(const InputParameters & parameters)
+  : AuxKernel(parameters),
+    // Both the old and the current values to make average time integration second order
+    _scalars(coupledValues("scalars")),
+    _scalars_old(coupledValuesOld("scalars"))
+{
+}
+
+void TimeAverageAux::initialSetup()
+{
+  // size average arrays after initialisation
+  _average.resize(_scalars[0]->size());
+  _average_old.resize(_scalars_old[0]->size());
+}
+
+void TimeAverageAux::timestepSetup()
+{
+  // set average old for the time step
+  _average_old = _average;
+}
+
+// template specialisation for Real
+Real TimeAverageAux::computeValue()
+{
+  const Real coeff =  _dt/_t;
+  Real value =1., value_old=1.;
+
+  // compute value and old value using product of input scalars
+  for (auto& v: _scalars){
+    value *= (*v)[_qp];
+  }
+  for (auto& v: _scalars_old){
+    value_old*= (*v)[_qp];
+  }
+
+  // Add weighted contribution of current step. Average contribution
+  // \frac{1}{T}\int_{0}^{T} f(t) dt
+  // approximated using Trapezoid rule. For each step
+  // \Delta t(f_2 + f_1)/2
+  _average[_qp] = (1. - coeff)*_average_old[_qp] + 0.5*coeff*(value + value_old);
+
+  return _average[_qp];
+}

--- a/src/auxkernels/TimeAverageAux.C
+++ b/src/auxkernels/TimeAverageAux.C
@@ -7,10 +7,10 @@ TimeAverageAux::validParams()
 {
   InputParameters params = AuxKernel::validParams();
 
-  params.addClassDescription("AuxKernel that performs time averaging of variables."
-                             "");
+  params.addClassDescription("AuxKernel that performs time averaging of variables.");
   params.addRequiredCoupledVar("scalars",
-                       "Scalar variables to be averaged");
+                       "Scalar variables to be averaged. If multiple scalars are "
+                       "given the average of their product is given");
   return params;
 }
 TimeAverageAux::TimeAverageAux(const InputParameters & parameters)

--- a/src/auxkernels/TimeAverageAux.C
+++ b/src/auxkernels/TimeAverageAux.C
@@ -21,38 +21,23 @@ TimeAverageAux::TimeAverageAux(const InputParameters & parameters)
 {
 }
 
-void TimeAverageAux::initialSetup()
-{
-  // size average arrays after initialisation
-  _average.resize(_scalars[0]->size());
-  _average_old.resize(_scalars_old[0]->size());
-}
-
-void TimeAverageAux::timestepSetup()
-{
-  // set average old for the time step
-  _average_old = _average;
-}
-
-// template specialisation for Real
 Real TimeAverageAux::computeValue()
 {
   const Real coeff =  _dt/_t;
-  Real value =1., value_old=1.;
+  Real val =1., val_old=1.;
 
   // compute value and old value using product of input scalars
   for (auto& v: _scalars){
-    value *= (*v)[_qp];
+    val *= (*v)[_qp];
   }
   for (auto& v: _scalars_old){
-    value_old*= (*v)[_qp];
+    val_old*= (*v)[_qp];
   }
 
   // Add weighted contribution of current step. Average contribution
   // \frac{1}{T}\int_{0}^{T} f(t) dt
   // approximated using Trapezoid rule. For each step
   // \Delta t(f_2 + f_1)/2
-  _average[_qp] = (1. - coeff)*_average_old[_qp] + 0.5*coeff*(value + value_old);
 
-  return _average[_qp];
+  return (1. - coeff)*value()[_qp] + 0.5*coeff*(val + val_old);
 }

--- a/src/auxkernels/VectorTimeAverageAux.C
+++ b/src/auxkernels/VectorTimeAverageAux.C
@@ -1,0 +1,84 @@
+
+#include "VectorTimeAverageAux.h"
+
+registerMooseObject("ProteusApp", VectorTimeAverageAux);
+
+InputParameters
+VectorTimeAverageAux::validParams()
+{
+  InputParameters params = VectorAuxKernel::validParams();
+
+  params.addClassDescription("VectorAuxKernel that performs time averaging of vectors.");
+
+  params.addRequiredCoupledVar("vectors",
+                       "Vector variables to be time averaged."
+                       "If multiple vectors are provided the average of their "
+                       "scalar multiplication is given. ");
+
+  params.addCoupledVar("scalars",
+                       "Scalar variables to be included in the time average.");
+  return params;
+}
+VectorTimeAverageAux::VectorTimeAverageAux(const InputParameters & parameters)
+  : VectorAuxKernel(parameters),
+    // Both the old and the current values to make average time integration second order
+    _scalars(coupledValues("scalars")),
+    _scalars_old(coupledValuesOld("scalars")),
+    _vectors(coupledVectorValues("vectors")),
+    // There isn't a coupledVectorValuesOld method for some reason.
+    // Elements must be set later
+    _vectors_old(_vectors.size())
+{
+
+  // setting vectors old
+  for (int i =0; i<_vectors.size(); ++i){
+    _vectors_old[i] = &coupledVectorValueOld("vectors", i);
+  }
+}
+
+void VectorTimeAverageAux::initialSetup()
+{
+  // size average arrays after initialisation
+  _average.resize(_vectors[0]->size());
+  _average_old.resize(_vectors_old[0]->size());
+}
+
+void VectorTimeAverageAux::timestepSetup()
+{
+  // set average old for the time step
+  _average_old = _average;
+}
+
+RealVectorValue VectorTimeAverageAux::computeValue()
+{
+  const Real coeff =  _dt/_t;
+  RealVectorValue value ={1., 1., 1.}, value_old={1., 1., 1.};
+
+  // Multiply  value and value_old values by the scalars first
+  for (auto& v: _scalars){
+    value *= (*v)[_qp];
+  }
+  for (auto& v: _scalars_old){
+    value_old*= (*v)[_qp];
+  }
+
+  // Multiply  value and value_old values by the vectors component-wise
+  for (auto& v: _vectors){
+    for (int i=0; i< LIBMESH_DIM; ++i){
+      value(i) *= (*v)[_qp](i);
+    }
+  }
+  for (auto& v: _vectors_old){
+    for (int i=0; i< LIBMESH_DIM; ++i){
+      value_old(i) *= (*v)[_qp](i);
+    }
+  }
+
+  // Add weighted contribution of current step. Average contribution
+  // \frac{1}{T}\int_{0}^{T} f(t) dt
+  // approximated using Trapezoid rule. For each step
+  // \Delta t(f_2 + f_1)/2
+  _average[_qp] = (1. - coeff)*_average_old[_qp] + 0.5*coeff*(value + value_old);
+
+  return _average[_qp];
+}

--- a/src/auxkernels/VectorTimeAverageAux.C
+++ b/src/auxkernels/VectorTimeAverageAux.C
@@ -38,41 +38,28 @@ VectorTimeAverageAux::VectorTimeAverageAux(const InputParameters & parameters)
   }
 }
 
-void VectorTimeAverageAux::initialSetup()
-{
-  // size average arrays after initialisation
-  _average.resize(_vectors[0]->size());
-  _average_old.resize(_vectors_old[0]->size());
-}
-
-void VectorTimeAverageAux::timestepSetup()
-{
-  // set average old for the time step
-  _average_old = _average;
-}
-
 RealVectorValue VectorTimeAverageAux::computeValue()
 {
   const Real coeff =  _dt/_t;
-  RealVectorValue value ={1., 1., 1.}, value_old={1., 1., 1.};
+  RealVectorValue val ={1., 1., 1.}, val_old={1., 1., 1.};
 
   // Multiply  value and value_old values by the scalars first
   for (auto& v: _scalars){
-    value *= (*v)[_qp];
+    val *= (*v)[_qp];
   }
   for (auto& v: _scalars_old){
-    value_old*= (*v)[_qp];
+    val_old *= (*v)[_qp];
   }
 
   // Multiply  value and value_old values by the vectors component-wise
   for (auto& v: _vectors){
     for (int i=0; i< LIBMESH_DIM; ++i){
-      value(i) *= (*v)[_qp](i);
+      val(i) *= (*v)[_qp](i);
     }
   }
   for (auto& v: _vectors_old){
     for (int i=0; i< LIBMESH_DIM; ++i){
-      value_old(i) *= (*v)[_qp](i);
+      val_old(i) *= (*v)[_qp](i);
     }
   }
 
@@ -80,7 +67,5 @@ RealVectorValue VectorTimeAverageAux::computeValue()
   // \frac{1}{T}\int_{0}^{T} f(t) dt
   // approximated using Trapezoid rule. For each step
   // \Delta t(f_2 + f_1)/2
-  _average[_qp] = (1. - coeff)*_average_old[_qp] + 0.5*coeff*(value + value_old);
-
-  return _average[_qp];
+  return (1. - coeff)*value()[_qp] + 0.5*coeff*(val + val_old);
 }

--- a/src/auxkernels/VectorTimeAverageAux.C
+++ b/src/auxkernels/VectorTimeAverageAux.C
@@ -18,7 +18,7 @@ VectorTimeAverageAux::validParams()
   params.addCoupledVar("scalars",
                        "Scalar variables to be included in the time average. "
                        "If scalars are are given the average of their product with the vector "
-                       "averages is given");
+                       "averages is given.");
   return params;
 }
 VectorTimeAverageAux::VectorTimeAverageAux(const InputParameters & parameters)
@@ -33,7 +33,7 @@ VectorTimeAverageAux::VectorTimeAverageAux(const InputParameters & parameters)
 {
 
   // setting vectors old
-  for (int i =0; i<_vectors.size(); ++i){
+  for (int i=0; i<_vectors.size(); ++i){
     _vectors_old[i] = &coupledVectorValueOld("vectors", i);
   }
 }
@@ -43,7 +43,7 @@ RealVectorValue VectorTimeAverageAux::computeValue()
   const Real coeff =  _dt/_t;
   RealVectorValue val ={1., 1., 1.}, val_old={1., 1., 1.};
 
-  // Multiply  value and value_old values by the scalars first
+  // Multiply value and value_old values by the scalars first
   for (auto& v: _scalars){
     val *= (*v)[_qp];
   }
@@ -51,14 +51,14 @@ RealVectorValue VectorTimeAverageAux::computeValue()
     val_old *= (*v)[_qp];
   }
 
-  // Multiply  value and value_old values by the vectors component-wise
+  // Multiply value and value_old values by the vectors component-wise
   for (auto& v: _vectors){
-    for (int i=0; i< LIBMESH_DIM; ++i){
+    for (int i=0; i<LIBMESH_DIM; ++i){
       val(i) *= (*v)[_qp](i);
     }
   }
   for (auto& v: _vectors_old){
-    for (int i=0; i< LIBMESH_DIM; ++i){
+    for (int i=0; i<LIBMESH_DIM; ++i){
       val_old(i) *= (*v)[_qp](i);
     }
   }

--- a/src/auxkernels/VectorTimeAverageAux.C
+++ b/src/auxkernels/VectorTimeAverageAux.C
@@ -13,10 +13,12 @@ VectorTimeAverageAux::validParams()
   params.addRequiredCoupledVar("vectors",
                        "Vector variables to be time averaged."
                        "If multiple vectors are provided the average of their "
-                       "scalar multiplication is given. ");
+                       "component-wise multiplication is given. ");
 
   params.addCoupledVar("scalars",
-                       "Scalar variables to be included in the time average.");
+                       "Scalar variables to be included in the time average. "
+                       "If scalars are are given the average of their product with the vector "
+                       "averages is given");
   return params;
 }
 VectorTimeAverageAux::VectorTimeAverageAux(const InputParameters & parameters)


### PR DESCRIPTION
The implementation allows the time averaging of both scalar and vector variables. Arbitrary numbers of scalars and vectors can be provided, with the resulting average being the average of their product. In multiple vectors are provided to the VectorTimeAverageAux a component-wise average is given - returning the diagonal of the covariance tensor. It should be possible to add the full covariance matrix if inherited from ArrayAuxKernel but I haven't properly looked into that yet.

## Classes added
1. `TimeAverageAux`: time average for scalar outputs
2. `VectorTimeAverageAux`: time average for vector

